### PR TITLE
Guard against calling destroy() on a missing key.

### DIFF
--- a/web/app/models/channel/channel.js
+++ b/web/app/models/channel/channel.js
@@ -57,9 +57,11 @@ MetricsChannel.prototype.add = function(mkey) {
 // mkey - String
 //
 MetricsChannel.prototype.remove = function(mkey) {
-  this.touch()
-  this.requests[mkey].destroy()
-  delete this.requests[mkey]
+  if (this.requests[mkey]) {
+    this.touch()
+    this.requests[mkey].destroy()
+    delete this.requests[mkey]
+  }
 }
 
 MetricsChannel.prototype.onPoint = function(point) {


### PR DESCRIPTION
I have seen crashes in prod when requests[mkey] doesn't exist. Not sure why this is happening, which you might want to investigate, but this check is an obvious guard against throwing when it's not there.
