### PR TITLE
backend-pg: pin to legacy 0.0.7 schema on pg@8 / Node 18+

### DIFF
--- a/backend-pg/README.md
+++ b/backend-pg/README.md
@@ -1,6 +1,19 @@
 # Setup
 
-The setup script will create the tables and indices. As of 1.0.0 this requires [TimescaleDB](https://github.com/timescale/timescaledb) to be installed.
+The setup script will create the tables and indices.
 
     # Print usage.
     $ ./bin/setup.js
+
+## Schema notes
+
+This package (`@patrick.kokou/zag-backend-pg@^2.0.1`) is pinned to the
+legacy `0.0.7`-era schema (`prod_metrics_data` with
+`metrics_key/time_start/data text-blob`) so it interoperates with the
+existing production Cloud SQL deployment. It does **not** require
+TimescaleDB. The `pg` driver is upgraded to `^8` for Node 18+
+compatibility (the only practical change vs. `0.0.7`).
+
+The `master`-era schema migration (column-per-statistic +
+`prod_metrics_data_llq`) lives elsewhere in the repo's history; pick it
+up only when production Postgres is migrated.

--- a/backend-pg/index.js
+++ b/backend-pg/index.js
@@ -1,13 +1,20 @@
-'use strict';
+var pg = require('pg')
 
-const pg = require('pg')
-
-const reDup    = /^duplicate key value/
+var reDup    = /^duplicate key value/
   , reExists = /already exists/
-  , INT8OID = 20
-  , FLOAT8OID = 1022
+  , CONNECTION_TIMEOUT_MS = 10000
 
-const setup =
+// Legacy callers (zag-daemon configured from voxer config.json) pass connection
+// strings of the form "tcp://user:pass@host/db". pg-connection-string (used by
+// pg@7+) does not recognize the "tcp://" scheme and silently falls back to
+// defaults (localhost + no auth), which fails closed without a clear error.
+// Normalize to the canonical scheme so the parse is unambiguous.
+function normalizeConnectionString(url) {
+  if (typeof url !== 'string') return url
+  return url.replace(/^tcp:\/\//, 'postgresql://')
+}
+
+var setup =
   [ "CREATE TABLE $env_metrics_keys ("
   + "  metrics_key varchar(512) NOT NULL CONSTRAINT $env_key_idx UNIQUE,"
   + "  type varchar(255) NOT NULL,"
@@ -15,27 +22,11 @@ const setup =
   + ")"
   , "CREATE TABLE $env_metrics_data ("
   + "  metrics_key varchar(512) NOT NULL,"
-  + "  ts bigint NOT NULL,"
-  + "  count bigint NOT NULL,"
-  + "  max double precision NULL,"
-  + "  mean double precision NULL,"
-  + "  median double precision NULL,"
-  + "  std_dev double precision NULL,"
-  + "  p10 double precision NULL,"
-  + "  p75 double precision NULL,"
-  + "  p95 double precision NULL,"
-  + "  p99 double precision NULL"
+  + "  time_start bigint NOT NULL,"
+  + "  data text NOT NULL"
   + ")"
-  , "CREATE UNIQUE INDEX $env_key_time_idx ON $env_metrics_data (metrics_key, ts)"
-  , "SELECT create_hypertable('$env_metrics_data', 'ts', chunk_time_interval => 604800000)"
-  , "CREATE TABLE $env_metrics_data_llq ("
-  + "  metrics_key varchar(512) NOT NULL,"
-  + "  ts bigint NOT NULL,"
-  + "  bucket double precision NOT NULL,"
-  + "  frequency double precision NOT NULL"
-  + ")"
-  , "CREATE INDEX $env_key_time_llq_idx ON $env_metrics_data_llq (metrics_key, ts)"
-  , "SELECT create_hypertable('$env_metrics_data_llq', 'ts', chunk_time_interval => 604800000)"
+  , "CREATE UNIQUE INDEX $env_key_time_idx ON $env_metrics_data (metrics_key, time_start)"
+
   , "CREATE TABLE $env_metrics_tags ("
   + "  id varchar(255) NOT NULL,"
   + "  ts bigint NOT NULL,"
@@ -86,7 +77,6 @@ function PostgresBackend(options) {
   // Tables
   this.tKeys       = this.env + "_metrics_keys"
   this.tData       = this.env + "_metrics_data"
-  this.tLlqData    = this.env + "_metrics_data_llq"
   this.tTags       = this.env + "_metrics_tags"
   this.tRules      = this.env + "_metrics_rules"
   this.tDashboards = this.env + "_metrics_dashboards"
@@ -96,12 +86,6 @@ function PostgresBackend(options) {
   var _this = this
   this._onKeyInsert   = function(err) { _this.onKeyInsert(err) }
   this._onPointInsert = function(err) { _this.onPointInsert(err) }
-}
-
-PostgresBackend.prototype.numberTypeParser = function (val) {
-  if (val) {
-    return parseFloat(val);
-  }
 }
 
 PostgresBackend.prototype.close = function() { this.client.end() }
@@ -125,6 +109,7 @@ PostgresBackend.prototype.setup = function(callback) {
   }
 }
 
+
 ///
 /// Metrics
 ///
@@ -133,66 +118,37 @@ PostgresBackend.prototype.setup = function(callback) {
 // start - Integer timestamp (ms)
 // end   - Integer timestamp (ms)
 // callback(err, [point])
-PostgresBackend.prototype.getLlqPoints = function(mkey, start, end, callback) {
-  const points = [];
-  const sqlString = `
-  SELECT
-  ts,
-  bucket,
-  frequency
-  FROM ${this.tLlqData}
-  WHERE metrics_key=$1
-  AND ts>=$2
-  AND ts<=$3
-  ORDER BY ts;
-  `;
-  this.query(sqlString, [mkey, start, end], (err, res) => {
-    if (err) return callback(err);
-    let result = {};
-    res.rows.forEach((row, index) => {
-      if (!result.ts) {
-        result = { ts: row.ts, data: {} };
-      }
-      result.data[row.bucket] = row.frequency;
-      if (index === res.rows.length - 1 || res.rows[index + 1].ts !== row.ts) {
-        points.push(result);
-        result = {};
-      }
-    });
-    callback(null, points)
-  });
-
-}
-
-// mkey  - String
-// start - Integer timestamp (ms)
-// end   - Integer timestamp (ms)
-// callback(err, [point])
 PostgresBackend.prototype.getPoints = function(mkey, start, end, callback) {
-  if (mkey.indexOf('@llq') > -1) {
-    return this.getLlqPoints(...arguments);
-  }
   this.query
-  (`SELECT
-    ts,
-    count,
-    mean,
-    max,
-    median,
-    std_dev,
-    p10,
-    p75,
-    p95,
-    p99
-    FROM ${this.tData}
-    WHERE metrics_key=$1
-    AND ts>=$2
-    AND ts<=$3
-    ORDER BY ts`,
-  [mkey, start, end], (err, res) => {
-    callback(err, res.rows);
-  });
+  ( "SELECT * FROM " + this.tData + " "
+  + "WHERE metrics_key=$1 "
+  + "AND time_start>=$2 "
+  + "AND time_start<=$3 "
+  + "ORDER BY time_start",
+  [mkey, toHour(start), toHour(end)], function(err, res) {
+    if (err) return callback(err)
+    var rows   = res.rows
+      , points = []
+    for (var i = 0, off = 0; i < rows.length; i++) {
+      appendPoints(points, parseRow(rows[i].data), start, end)
+    }
+    callback(null, points)
+  })
 }
+
+function appendPoints(allPoints, newPoints, start, end) {
+  var count = allPoints.length
+    , last  = count ? allPoints[count - 1].ts : 0
+  for (var i = 0; i < newPoints.length; i++) {
+    var pt = newPoints[i]
+      , ts = pt.ts
+    if (ts > last && start <= ts && ts <= end) {
+      allPoints.push(pt)
+    }
+    last = Math.max(last, ts)
+  }
+}
+
 // points - { mkey : point }
 PostgresBackend.prototype.savePoints = function(points) {
   var mkeys = Object.keys(points)
@@ -219,49 +175,29 @@ function identify(pt) {
        : "counter"
 }
 
-PostgresBackend.prototype.saveLlqPoint = function (mkey, pt, callback) {
-  const done  = callback || this._onPointInsert;
-  const sqlString = `INSERT INTO ${this.tLlqData} SELECT $1, $2, cast(key as double precision) as bucket, cast(value as double precision) as frequency FROM json_each_text($3)`;
-  const sqlParams = [mkey, pt.ts, JSON.stringify(pt.data)];
-  this.query(sqlString, sqlParams, done);
-}
+var msHour = 1000 * 60 * 60
+
+function toHour(ms) { return ms - (ms % msHour) }
 
 PostgresBackend.prototype.savePoint = function(mkey, pt, callback) {
-  const done  = callback || this._onPointInsert;
-  if (pt.empty === true) {
-    return done(null, null);
-  }
-  if (mkey.indexOf('@llq') > -1) {
-    return this.saveLlqPoint(...arguments);
-  }
-  const sqlString = `INSERT INTO ${this.tData} (
-    metrics_key,
-    ts,
-    count,
-    max,
-    mean,
-    median,
-    std_dev,
-    p10,
-    p75,
-    p95,
-    p99
-  ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)`;
-  const sqlParams = [
-    mkey,
-    pt.ts,
-    pt.count,
-    pt.max,
-    pt.mean,
-    pt.median,
-    pt.std_dev,
-    pt.p10,
-    pt.p75,
-    pt.p95,
-    pt.p99
-  ];
-  this.query(sqlString, sqlParams, done);
-};
+  var _this = this
+    , chunk = toHour(pt.ts)
+    , done  = callback || this._onPointInsert
+  this.query
+  ( "UPDATE " + _this.tData + " "
+  + "SET data=trim(trailing ']' from data) || $1"
+  + "WHERE metrics_key=$2 AND time_start=$3",
+  [", " + JSON.stringify(pt) + "]", mkey, chunk], function (err, result) {
+    // if there is an error or we have updated a row then move on
+    // if we did not update a row then we need to insert a row
+    if (err || (result && result.rowCount === 1)) {
+      return done(err, result);
+    }
+    _this.query
+    ( "INSERT INTO " + _this.tData + " VALUES($1, $2, $3)",
+      [mkey, chunk, JSON.stringify([pt])], done)
+  })
+}
 
 PostgresBackend.prototype.onKeyInsert = function(err) {
   if (err && !reDup.test(err.message)) this.onError(err)
@@ -402,10 +338,9 @@ PostgresBackend.prototype.listDashboards = function(callback) {
 // Like `client.query`, but record latency and errors.
 PostgresBackend.prototype.query = function(sql, params, callback) {
   var agent = this.agent
-    , sql = sql.trim()
     , start = Date.now()
     , index = sql.indexOf(" ")
-    , cmd   = (index === -1 ? sql : sql.slice(0, index)).trim()
+    , cmd   = index === -1 ? sql : sql.slice(0, index)
     , table = this.reTable.exec(sql)
 
   table = table ? table[1] : "unknown"
@@ -421,16 +356,31 @@ PostgresBackend.prototype.query = function(sql, params, callback) {
 
 PostgresBackend.prototype.reconnect = function() {
   var isReconnect = !!this.client
-  if (this.client) this.client.end()
-  this.client = new pg.Client(this.url)
-  this.client.setTypeParser(INT8OID, this.numberTypeParser);
-  this.client.setTypeParser(FLOAT8OID, this.numberTypeParser);
+  if (this.client) {
+    // pg@8 Client#end returns a Promise; swallow tear-down errors so a stale
+    // socket can't mask the new connect error below.
+    try { Promise.resolve(this.client.end()).catch(noop) } catch (_) {}
+  }
+  this.client = new pg.Client({
+    connectionString: normalizeConnectionString(this.url),
+    // Without this, pg@8 will block forever on a half-open TCP socket (e.g.
+    // a transient Cloud SQL stall) and zag-daemon will silently no-op every
+    // savePoints flush. Bound the wait so connect failures surface loudly via
+    // the error handler instead of looking like a healthy idle client.
+    connectionTimeoutMillis: CONNECTION_TIMEOUT_MS
+  })
   this.client.on("error", this.onConnectionError.bind(this))
 
   var _this = this
   this.client.connect(function(err) {
     if (err) {
-      if (!isReconnect) throw err
+      if (!isReconnect) {
+        // Surface the failure to the configured error handler so the caller
+        // can log it; then fall through into the reconnect retry loop. Throwing
+        // here (the v0.0.7 behavior) crashes the daemon hard before any retry
+        // can run, which made transient startup races unrecoverable.
+        _this.onError(err)
+      }
       setTimeout(_this.reconnect.bind(_this), 1000)
     }
   })

--- a/backend-pg/index.js
+++ b/backend-pg/index.js
@@ -131,7 +131,7 @@ PostgresBackend.prototype.getPoints = function(mkey, start, end, callback) {
     if (err) return callback(err)
     var rows   = res.rows
       , points = []
-    for (var i = 0, off = 0; i < rows.length; i++) {
+    for (var i = 0; i < rows.length; i++) {
       appendPoints(points, parseRow(rows[i].data), start, end)
     }
     callback(null, points)

--- a/backend-pg/index.js
+++ b/backend-pg/index.js
@@ -88,7 +88,9 @@ function PostgresBackend(options) {
   this._onPointInsert = function(err) { _this.onPointInsert(err) }
 }
 
-PostgresBackend.prototype.close = function() { this.client.end() }
+PostgresBackend.prototype.close = function() {
+  try { Promise.resolve(this.client.end()).catch(noop) } catch (_) {}
+}
 
 PostgresBackend.prototype.setup = function(callback) {
   var _this = this
@@ -185,7 +187,7 @@ PostgresBackend.prototype.savePoint = function(mkey, pt, callback) {
     , done  = callback || this._onPointInsert
   this.query
   ( "UPDATE " + _this.tData + " "
-  + "SET data=trim(trailing ']' from data) || $1"
+  + "SET data=trim(trailing ']' from data) || $1 "
   + "WHERE metrics_key=$2 AND time_start=$3",
   [", " + JSON.stringify(pt) + "]", mkey, chunk], function (err, result) {
     // if there is an error or we have updated a row then move on

--- a/backend-pg/package-lock.json
+++ b/backend-pg/package-lock.json
@@ -1,0 +1,165 @@
+{
+  "name": "@patrick.kokou/zag-backend-pg",
+  "version": "2.0.1",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@patrick.kokou/zag-backend-pg",
+      "version": "2.0.1",
+      "dependencies": {
+        "pg": "^8.13.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/pg": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.20.0.tgz",
+      "integrity": "sha512-ldhMxz2r8fl/6QkXnBD3CR9/xg694oT6DZQ2s6c/RI28OjtSOpxnPrUCGOBJ46RCUxcWdx3p6kw/xnDHjKvaRA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "pg-connection-string": "^2.12.0",
+        "pg-pool": "^3.13.0",
+        "pg-protocol": "^1.13.0",
+        "pg-types": "2.2.0",
+        "pgpass": "1.0.5"
+      },
+      "engines": {
+        "node": ">= 16.0.0"
+      },
+      "optionalDependencies": {
+        "pg-cloudflare": "^1.3.0"
+      },
+      "peerDependencies": {
+        "pg-native": ">=3.0.1"
+      },
+      "peerDependenciesMeta": {
+        "pg-native": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/pg-cloudflare": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/pg-cloudflare/-/pg-cloudflare-1.3.0.tgz",
+      "integrity": "sha512-6lswVVSztmHiRtD6I8hw4qP/nDm1EJbKMRhf3HCYaqud7frGysPv7FYJ5noZQdhQtN2xJnimfMtvQq21pdbzyQ==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/pg-connection-string": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.12.0.tgz",
+      "integrity": "sha512-U7qg+bpswf3Cs5xLzRqbXbQl85ng0mfSV/J0nnA31MCLgvEaAo7CIhmeyrmJpOr7o+zm0rXK+hNnT5l9RHkCkQ==",
+      "license": "MIT"
+    },
+    "node_modules/pg-int8": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
+      "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/pg-pool": {
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.13.0.tgz",
+      "integrity": "sha512-gB+R+Xud1gLFuRD/QgOIgGOBE2KCQPaPwkzBBGC9oG69pHTkhQeIuejVIk3/cnDyX39av2AxomQiyPT13WKHQA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "pg": ">=8.0"
+      }
+    },
+    "node_modules/pg-protocol": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.13.0.tgz",
+      "integrity": "sha512-zzdvXfS6v89r6v7OcFCHfHlyG/wvry1ALxZo4LqgUoy7W9xhBDMaqOuMiF3qEV45VqsN6rdlcehHrfDtlCPc8w==",
+      "license": "MIT"
+    },
+    "node_modules/pg-types": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.2.0.tgz",
+      "integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
+      "license": "MIT",
+      "dependencies": {
+        "pg-int8": "1.0.1",
+        "postgres-array": "~2.0.0",
+        "postgres-bytea": "~1.0.0",
+        "postgres-date": "~1.0.4",
+        "postgres-interval": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/pgpass": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-1.0.5.tgz",
+      "integrity": "sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==",
+      "license": "MIT",
+      "dependencies": {
+        "split2": "^4.1.0"
+      }
+    },
+    "node_modules/postgres-array": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
+      "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/postgres-bytea": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.1.tgz",
+      "integrity": "sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-date": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.7.tgz",
+      "integrity": "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-interval": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.2.0.tgz",
+      "integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "xtend": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/split2": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 10.x"
+      }
+    },
+    "node_modules/xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4"
+      }
+    }
+  }
+}

--- a/backend-pg/package-lock.json
+++ b/backend-pg/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@patrick.kokou/zag-backend-pg",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/backend-pg/package-lock.json
+++ b/backend-pg/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "@patrick.kokou/zag-backend-pg",
-      "version": "2.0.1",
+      "version": "2.0.2",
       "dependencies": {
         "pg": "^8.13.0"
       },

--- a/backend-pg/package.json
+++ b/backend-pg/package.json
@@ -1,8 +1,8 @@
 {
-  "name": "zag-backend-pg",
-  "version": "1.0.0",
+  "name": "@patrick.kokou/zag-backend-pg",
+  "version": "2.0.1",
   "author": "sentientwaffle",
-  "description": "postgres backend for zag metrics",
+  "description": "postgres backend for zag metrics — pinned to the legacy 0.0.7 schema (prod_metrics_data with metrics_key/time_start/data) on pg@^8 for Node 18+ compatibility",
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
@@ -16,7 +16,10 @@
     "zag",
     "metrics"
   ],
+  "engines": {
+    "node": ">=18"
+  },
   "dependencies": {
-    "pg": "7.4.1"
+    "pg": "^8.13.0"
   }
 }

--- a/backend-pg/package.json
+++ b/backend-pg/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@patrick.kokou/zag-backend-pg",
-  "version": "2.0.1",
-  "author": "sentientwaffle",
+  "version": "2.0.2",
+  "author": "sentientwaffle, Patrick Kokou",
   "description": "postgres backend for zag metrics — pinned to the legacy 0.0.7 schema (prod_metrics_data with metrics_key/time_start/data) on pg@^8 for Node 18+ compatibility",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
The previous fork (@patrick.kokou/zag-backend-pg@2.0.0, merged in PR fix/backend-pg) was based on master's column-per-statistic schema (prod_metrics_data with ts/count/max/mean/... + a separate prod_metrics_data_llq table). That schema was never deployed to the production Cloud SQL — production still has the legacy 0.0.7 layout (prod_metrics_data with metrics_key/time_start/data text-blob).

Result on gcp1-prod-0064: ms16 connects to Postgres but every INSERT fails with `column "ts" does not exist` /
`relation "prod_metrics_data_llq" does not exist`. Metrics still don't land because the SQL targets columns that aren't there.

This commit revert backend-pg/{index.js,README.md} to the 0.0.7-era contract (commit 1f3c1ef, byte-identical to the deployed zag-backend-pg@0.0.7) and layers in only the driver-level fixes needed for Node 18+:

- pg dep: ~3.2.0 -> ^8.13.0
- new pg.Client({ connectionString, connectionTimeoutMillis: 10000 }) so half-open Cloud SQL sockets fail loudly instead of silently hanging (the original gcp1-prod-0064 outage)
- normalize legacy tcp:// connection strings to postgresql:// (pg-connection-string@2 doesn't accept tcp://)
- swallow tear-down errors from Promise-returning Client#end (pg@8)
- route initial connect failure through onError instead of throw, so the existing reconnect loop can recover from transient startup races

Schema, savePoint UPDATE-then-INSERT trick, and the entire public API surface are unchanged from 0.0.7 — interoperable with the legacy fleet (gcp1-prod-0048..0063) writing to the same tables.

To be published as @patrick.kokou/zag-backend-pg@2.0.1. Voxer/server's server_upgrade branch is already pinned to ^2.0.0 and will pick this up via npm install / git-pull-server after publish.

The master-era schema migration (column-per-statistic + prod_metrics_data_llq, the path forward when prod Postgres is migrated) remains in the repo's history; this commit does NOT reapply it.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches metrics persistence and Postgres connection/reconnect behavior; incorrect schema assumptions or connection handling could drop or delay metric writes, but changes are localized to the backend-pg adapter.
> 
> **Overview**
> Reverts `backend-pg` to write/read metrics using the legacy Cloud SQL schema (`metrics_key` + `time_start` + JSON `data` blob) and removes the newer column-per-statistic/`*_llq` table logic so inserts target the production layout.
> 
> Upgrades the `pg` dependency to `^8` and hardens connectivity by normalizing legacy `tcp://` URLs, adding a connection timeout, and making disconnect/reconnect paths Promise-safe while routing initial connect failures through `onError` instead of throwing.
> 
> Updates package metadata (scoped name, Node `>=18` engine) and documents the schema pin and TimescaleDB no-longer-required setup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 254aa8ca58913ac142a0f58a3c7ce783f31d316f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->